### PR TITLE
Update for futures 0.3.0-alpha.13.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ proc-macro = true
 syn = { version = "0.15", features = ["full"] }
 quote = "0.6"
 tokio = { version = "0.1", features = ["async-await-preview"] }
-futures-preview = { version = "0.3.0-alpha.10", features = ["tokio-compat"] }
+futures-preview = { version = "0.3.0-alpha.13", features = ["compat"] }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a simple crate that provides a procedural macro similar to `#[test]` tha
 
 # Usage
 
-First, you must be on nightly rust as of `12-02-2018`. Add the crate to your `Cargo.toml`.
+First, you must be on nightly rust as of `2019-02-15`. Add the crate to your `Cargo.toml`.
 
 ``` toml
 [dependencies]
@@ -32,7 +32,7 @@ futures-preview = { version = "0.3.0-alpha.10", features = ["tokio-compat"] }
 Once, you have all these dependencies you can then use the attribute like so.
 
 ``` rust
-#![feature(pin, async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro, futures_api)]
 
 extern crate futures;
 extern crate tokio;
@@ -53,7 +53,7 @@ This will spin up a tokio runtime and block on the `basic` function. This genera
 fn basic() {
 	// -- snip --
     let mut rt = Runtime::new().unwrap();
-	
+
 	rt.block_on(fut().unit_error().boxed().compat()).unwrap();
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! # Usage
 //!
-//! First, you must be on nightly rust as of `12-02-2018`. Add the crate to your `Cargo.toml`.
+//! First, you must be on nightly rust as of `2019-02-15`. Add the crate to your `Cargo.toml`.
 //!
 //! ``` toml
 //! [dependencies]
@@ -20,7 +20,7 @@
 //! Once, you have all these dependencies you can then use the attribute like so.
 //!
 //! ``` rust
-//! #![feature(pin, async_await, await_macro, futures_api)]
+//! #![feature(async_await, await_macro, futures_api)]
 //!
 //! extern crate futures;
 //! extern crate tokio;
@@ -48,7 +48,7 @@
 //!
 //! You can also use a current thread runtime by importing `use tokio_async_await_test::async_current_thread_test;`.
 
-#![feature(pin, async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro, futures_api)]
 
 extern crate proc_macro;
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,4 +1,4 @@
-#![feature(pin, async_await, await_macro, futures_api)]
+#![feature(async_await, await_macro, futures_api)]
 
 extern crate futures;
 extern crate tokio;


### PR DESCRIPTION
Thanks, I have found this library useful :)

Futures preview no longer has a `tokio-compat` feature, this PR updates things to work with the latest version and current nightly rust.