### PR TITLE
update to futures-preview 0.3.0-alpha.17 and drop futures0.1 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,4 @@ proc-macro = true
 [dependencies]
 syn = { version = "0.15", features = ["full"] }
 quote = "0.6"
-tokio = { version = "0.1", features = ["async-await-preview"] }
-futures-preview = { version = "0.3.0-alpha.13", features = ["compat"] }
+futures-preview = { version = "0.3.0-alpha.17"}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,41 +1,12 @@
-#![feature(async_await, await_macro, futures_api)]
+#![feature(async_await)]
 
 extern crate futures;
-extern crate tokio;
-extern crate tokio_async_await_test;
 
-use tokio_async_await_test::{async_current_thread_test, async_test};
+use tokio_async_await_test::{async_test};
 
 #[async_test]
 async fn basic() {
-    await!(example_async_fn());
-}
-
-#[async_test]
-async fn basic_with_spawn() {
-    tokio::spawn_async(
-        async {
-            await!(example_async_fn());
-        },
-    );
-
-    await!(example_async_fn());
-}
-
-#[async_current_thread_test]
-async fn basic_current_thread() {
-    await!(example_async_fn());
-}
-
-#[async_current_thread_test]
-async fn basic_current_thread_with_spawn() {
-    tokio::spawn_async(
-        async {
-            await!(example_async_fn());
-        },
-    );
-
-    await!(example_async_fn());
+    example_async_fn().await;
 }
 
 async fn example_async_fn() {


### PR DESCRIPTION
This is probably better off as a fork, but I'd offer it in case you wanted it.

This commit switches to the upcoming futures runtime (which I believe will allow plugable alternatives to tokio).

It might also be worth renaming the crate to `async-await-test` instead since tokio is no longer explicitly required.

Completely understandable if this PR isn't the direction you want to go - happy to fork.

Cheers!